### PR TITLE
Rewrite fmap id for GenHaxl Selective's instance 

### DIFF
--- a/Haxl/Core/Monad.hs
+++ b/Haxl/Core/Monad.hs
@@ -643,7 +643,11 @@ instance Selective (GenHaxl u) where
   biselect = biselectGenHaxl
 
 biselectGenHaxl :: (t -> Either a1 (b -> a1)) -> (a -> Either a1 b) -> GenHaxl u t -> GenHaxl u a -> GenHaxl u a1
-biselectGenHaxl f g (GenHaxl x) (GenHaxl y) = GenHaxl $ \env@Env{..} -> do
+biselectGenHaxl f g x y = GenHaxl (biselectInner f g x y)
+{-# INLINE biselectGenHaxl #-}
+
+biselectInner :: (t -> Either a1 (b -> a1)) -> (a -> Either a1 b) -> GenHaxl u t -> GenHaxl u a -> Env u -> IO (Result u a1)
+biselectInner f g (GenHaxl x) (GenHaxl y) env@Env{..} = do
     let !senv = speculate env
     rx <- x env -- non speculative
     case rx of
@@ -666,7 +670,7 @@ biselectGenHaxl f g (GenHaxl x) (GenHaxl y) = GenHaxl $ \env@Env{..} -> do
           -- suboptimal because the right side might wake up first,
           -- but handling this non-determinism would involve a much
           -- more complicated implementation here.
-{-# INLINE biselectGenHaxl #-}
+{-# INLINE biselectInner #-}
 
 -- -----------------------------------------------------------------------------
 -- Env utils

--- a/Haxl/Core/Monad.hs
+++ b/Haxl/Core/Monad.hs
@@ -834,7 +834,7 @@ GenHaxl a `pOrOld` GenHaxl b = GenHaxl $ \env@Env{..} -> do
           -- is whatever the left side was waiting for.  This is
           -- suboptimal because the right side might wake up first,
           -- but handling this non-determinism would involve a much
--- more complicated implementation here.
+          -- more complicated implementation here.
 
 pAndOld :: GenHaxl u Bool -> GenHaxl u Bool -> GenHaxl u Bool
 GenHaxl a `pAndOld` GenHaxl b = GenHaxl $ \env@Env{..} -> do

--- a/Haxl/Core/Parallel.hs
+++ b/Haxl/Core/Parallel.hs
@@ -18,35 +18,3 @@ module Haxl.Core.Parallel
   ) where
 
 import Haxl.Core.Monad
-
--- -----------------------------------------------------------------------------
--- Parallel operations
-
--- Bind more tightly than .&&, .||
-infixr 5 `pAnd`
-infixr 4 `pOr`
-
--- | Parallel version of '(.||)'.  Both arguments are evaluated in
--- parallel, and if either returns 'True' then the other is
--- not evaluated any further.
---
--- WARNING: exceptions may be unpredictable when using 'pOr'.  If one
--- argument returns 'True' before the other completes, then 'pOr'
--- returns 'True' immediately, ignoring a possible exception that
--- the other argument may have produced if it had been allowed to
--- complete.
-pOr :: GenHaxl u Bool -> GenHaxl u Bool -> GenHaxl u Bool
-pOr = (<||>)
-
-
--- | Parallel version of '(.&&)'.  Both arguments are evaluated in
--- parallel, and if either returns 'False' then the other is
--- not evaluated any further.
---
--- WARNING: exceptions may be unpredictable when using 'pAnd'.  If one
--- argument returns 'False' before the other completes, then 'pAnd'
--- returns 'False' immediately, ignoring a possible exception that
--- the other argument may have produced if it had been allowed to
--- complete.
-pAnd :: GenHaxl u Bool -> GenHaxl u Bool -> GenHaxl u Bool
-pAnd = (<&&>)

--- a/Haxl/Core/Selective.hs
+++ b/Haxl/Core/Selective.hs
@@ -9,6 +9,8 @@ module Haxl.Core.Selective
   , branch
   , race
   , ifS
+  , (<||>)
+  , (<&&>)
   ) where
 
 import Data.Bool
@@ -21,27 +23,7 @@ import Data.Bool
 --
 -- This instance uses a "curried" version of the 'biselect' from the paper.
 class Applicative f => Selective f where
-    biselect :: (a -> Either c (d -> c)) -> (b -> Either c d) -> f a -> f b -> f c
-
-    -- | A lifted version of lazy Boolean OR.
-    (<||>) :: f Bool -> f Bool -> f Bool
-    (<||>) x y = biselect f g x y
-      where
-        f :: Bool -> Either Bool (Bool -> Bool)
-        f x = if x then Left True else Right id
-        g :: Bool -> Either Bool Bool
-        g x = if x then Left True else Right False
-    {-# INLINEABLE (<||>) #-}
-
-    -- | A lifted version of lazy Boolean AND.
-    (<&&>) :: f Bool -> f Bool -> f Bool
-    (<&&>) x y = biselect f g x y
-      where
-        f :: Bool -> Either Bool (Bool -> Bool)
-        f x = if x then Right id else Left False
-        g :: Bool -> Either Bool Bool
-        g x = if x then Right True else Left False
-    {-# INLINEABLE (<&&>) #-}
+  biselect :: (a -> Either c (d -> c)) -> (b -> Either c d) -> f a -> f b -> f c
 
 select :: Selective f => f (Either a b) -> f (a -> b) -> f b
 select x y = biselect (either (Right . (flip ($))) Left) Right x y
@@ -73,3 +55,23 @@ ifS :: Selective f => f Bool -> f a -> f a -> f a
 ifS i t e = branch (boolToEither <$> i) (const <$> t) (const <$> e)
   where
     boolToEither = bool (Right ()) (Left ())
+
+-- | A lifted version of lazy Boolean OR.
+(<||>) :: Selective f => f Bool -> f Bool -> f Bool
+(<||>) x y = biselect f g x y
+  where
+    f :: Bool -> Either Bool (Bool -> Bool)
+    f x = if x then Left True else Right id
+    g :: Bool -> Either Bool Bool
+    g x = if x then Left True else Right False
+{-# INLINE (<||>) #-}
+
+-- | A lifted version of lazy Boolean AND.
+(<&&>) :: Selective f => f Bool -> f Bool -> f Bool
+(<&&>) x y = biselect f g x y
+  where
+    f :: Bool -> Either Bool (Bool -> Bool)
+    f x = if x then Right id else Left False
+    g :: Bool -> Either Bool Bool
+    g x = if x then Right True else Left False
+{-# INLINE (<&&>) #-}


### PR DESCRIPTION
Hi,

This:

* Add a rule to rewrite `fmap (\x -> x)` to `id` on `GenHaxl` functor's instance.
This rule fires correctly and `unHaxl ((either id dc . g) <$> GenHaxl y) env` fom `<||>` inlining will indeed be rewritten to `unHaxl (GenHaxl y) env`.

* Add some `INLINEABLE` pragma, `<||>` and `<&&>` to Selective's class definition.
This change allows `<||>` and `<&&>` from the `GenHaxl` Selective's instance to be automatically optimized using the above rule.
This is normally not the case since `<||>` is defined for all `Selective` instance and thus need to be specialized for the `GenHaxl` one to be optimized.

A maybe simpler solution for the second point is to defines `pOr` and `pAnd` in terms of `Selective.<||>` and `Selective.<&&>` in `Monad.Core.Haxl` to directly force the specialization and the `fmap` optimization.